### PR TITLE
Lowered Thread.sleep to make sure adop_gitlab.groovy executes before adop_ldap.groovy

### DIFF
--- a/resources/init.groovy.d/adop_general.groovy
+++ b/resources/init.groovy.d/adop_general.groovy
@@ -169,7 +169,7 @@ Thread.start {
     if(!ssh_credentials_file_exist) {
 
         def ssh_key_domain = com.cloudbees.plugins.credentials.domains.Domain.global()
-        def ssh_key_file = new FileCredentialsImpl(ssh_key_scope, ssh_key_file_id, ssh_key_file_description, fileItem, null, null)
+        def ssh_key_file = new FileCredentialsImpl(ssh_key_scope, ssh_key_file_id, ssh_key_file_description, fileItem, null, "")
 
         system_credentials_provider.addCredentials(ssh_key_domain,ssh_key_file)
     }

--- a/resources/init.groovy.d/adop_gitlab.groovy
+++ b/resources/init.groovy.d/adop_gitlab.groovy
@@ -25,7 +25,7 @@ if (!password) {
 def instance = Jenkins.getInstance()
 
 Thread.start {
-    sleep 15000
+    sleep 9000
 
     def credentialDescription = "Gitlab Administrator Credentials"
     def credentialsId = "gitlab-admin-credentials"


### PR DESCRIPTION
…e ADOP_LDAP"

replaced null with double quotes in adop_general.groovy because new constructor is available for file descriptor